### PR TITLE
Documentation events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ yarn.lock
 package-lock.json
 *bak
 .vscode
+.tool-versions
 
 # visual studio code
 .history

--- a/src/pages/Docs/data.js
+++ b/src/pages/Docs/data.js
@@ -146,6 +146,13 @@ export const menu = [
   },
   {
     'name': <FormattedMessage
+      id="menu.metricsapi"
+      defaultMessage="Metrics API"
+    />,
+    'path': paths['metrics-api']
+  },
+  {
+    'name': <FormattedMessage
       id="menu.tokensapi"
       defaultMessage="Tokens API"
     />,
@@ -187,4 +194,3 @@ export const menu = [
     'path': paths['open-edition']
   }
 ];
-

--- a/src/pages/Docs/markdown/metrics-api.en-GB.md
+++ b/src/pages/Docs/markdown/metrics-api.en-GB.md
@@ -1,2 +1,29 @@
-# Metrics API Driver
-Pending documentation
+# Metrics API
+
+The Metrics API is both available as read-only via GET requests, and as write-read access 
+
+- **Metrics API Source**: https://github.com/hirmeos/metrics-api
+
+
+### API routes
+The following methods are allowed:
+
+| Method  | Route        | Description                                                                                                                     |
+| ------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `GET`   | `/measures`  | List the descriptions of the measures available in the API                                                                      |
+| `GET`   | `/events`    | Retrieves the measures from the API with various parameters, see below                                                          |
+
+
+### `GET /events` parameters
+
+When retrieving measures, you can (and should) provide some parameters to the request, they can be seen below:
+
+| Parameter   | Description                                                                                                              |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------ |
+| aggregation | The results can be aggregated on certain values, i.e. aggregation on `measure_uri`. Aggregation must be one of the following: empty, `measure_uri,country_uri`, `year,measure_uri`, `measure_uri,month`, `month,measure_uri`, `measure_uri,year`, `country_uri,measure_uri`, `measure_uri`. |
+| filter      | Many different options can be used in the filter, i.e. filtering on `measure_uri` or on `work_uri`. Those can be together or even used multiple times by separating them with a comma "`,`"                                                                                                 |
+
+Examples:
+
+- Example of simple query on a DOI and results aggregated by the measure_uri: `https://metrics-api.operas-eu.org/events?aggregation=measure_uri&filter=work_uri:info:doi:10.11647/obp.0020`
+- Example of the same query but selecting only a couple of measures: `https://metrics-api.operas-eu.org/events?aggregation=measure_uri&filter=work_uri:info:doi:10.11647/obp.0020,measure_uri:https://metrics.operas-eu.org/oapen/downloads/v1,measure_uri:https://metrics.operas-eu.org/obp/downloads/v1`


### PR DESCRIPTION
Start of the documentation for the Metrics API. The routes `/measures` and `/events` are described