### PR TITLE
Deleted wrong Hirmeos link from footer

### DIFF
--- a/src/layouts/Footer.js
+++ b/src/layouts/Footer.js
@@ -18,12 +18,6 @@ const FooterView = () => (
           title: <Icon type="github" />,
           href: 'https://github.com/hirmeos',
           blankTarget: true
-        },
-        {
-          key: 'HIRMEOS',
-          title: 'HIRMEOS',
-          href: 'http://www.hirmeos.eu',
-          blankTarget: true
         }
       ]}
       copyright={


### PR DESCRIPTION
Deleted the Hirmeos link from [src/layouts/Footer.js] as it wasn't correct.